### PR TITLE
Feature/crash fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /Tests/obj
 /MadChess.sln.DotSettings.user
 /Engine/Engine.csproj.user
+/Tests/Tests.csproj.user

--- a/Engine/Bitwise.cs
+++ b/Engine/Bitwise.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -10,8 +10,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq; // Use LINQ only for Debug.Asserts.
-using System.Runtime.CompilerServices;
+using System.Linq;
+using System.Runtime.CompilerServices; // Use LINQ only for Debug.Asserts.
 using System.Text;
 using System.Runtime.Intrinsics.X86;
 

--- a/Engine/Board.cs
+++ b/Engine/Board.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 
 namespace ErikTheCoder.MadChess.Engine
@@ -809,7 +810,6 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetSquare(int File, int Rank)
         {
             Debug.Assert(File >= 0 && File < 8);
@@ -831,87 +831,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetBlackSquare(int Square) => 63 - Square;
-
-
-        // ReSharper disable once UnusedMember.Global
-        public static Direction GetDirection(int FromSquare, int ToSquare)
-        {
-            int fromRank = WhiteRanks[FromSquare];
-            int fromFile = Files[FromSquare];
-            int fromUpDiagonal = UpDiagonals[FromSquare];
-            int fromDownDiagonal = DownDiagonals[FromSquare];
-            int toRank = WhiteRanks[ToSquare];
-            int toFile = Files[ToSquare];
-            int toUpDiagonal = UpDiagonals[ToSquare];
-            int toDownDiagonal = DownDiagonals[ToSquare];
-            Direction direction = GetSlidingDirection(fromRank, fromFile, fromUpDiagonal, fromDownDiagonal, toRank, toFile, toUpDiagonal, toDownDiagonal);
-            return direction == Direction.Unknown
-                ? GetKnightDirection(FromSquare, ToSquare, fromRank, fromFile, toRank, toFile)
-                : direction;
-        }
-
-
-        private static Direction GetSlidingDirection(int FromRank, int FromFile, int FromUpDiagonal, int FromDownDiagonal,
-            int ToRank, int ToFile, int ToUpDiagonal, int ToDownDiagonal)
-        {
-            if (FromRank == ToRank)
-            {
-                // Slide along rank
-                return ToFile > FromFile ? Direction.East : Direction.West;
-            }
-            if (FromFile == ToFile)
-            {
-                // Slide along file
-                return ToRank > FromRank ? Direction.North : Direction.South;
-            }
-            if (FromUpDiagonal == ToUpDiagonal)
-            {
-                // Slide along up diagonal
-                return ToFile > FromFile ? Direction.NorthEast : Direction.SouthWest;
-            }
-            if (FromDownDiagonal == ToDownDiagonal)
-            {
-                // Slide along down diagonal
-                return ToFile > FromFile ? Direction.SouthEast : Direction.NorthWest;
-            }
-            return Direction.Unknown;
-        }
-        
-        
-        private static Direction GetKnightDirection(int FromSquare, int ToSquare, int FromRank, int FromFile, int ToRank, int ToFile)
-        {
-            int distance = SquareDistances[FromSquare][ToSquare];
-            if (distance == 2)
-            {
-                int rankDistance = ToRank - FromRank;
-                int fileDistance = ToFile - FromFile;
-                // ReSharper disable ConvertIfStatementToSwitchStatement
-                if (rankDistance == 2)
-                {
-                    if (fileDistance == -1) return Direction.North2West1;
-                    if (fileDistance == 01) return Direction.North2East1;
-                }
-                if (rankDistance == 1)
-                {
-                    if (fileDistance == -2) return Direction.West2North1;
-                    if (fileDistance == 02) return Direction.East2North1;
-                }
-                if (rankDistance == -1)
-                {
-                    if (fileDistance == -2) return Direction.West2South1;
-                    if (fileDistance == 02) return Direction.East2South1;
-                }
-                if (rankDistance == -2)
-                {
-                    if (fileDistance == -1) return Direction.South2West1;
-                    if (fileDistance == 01) return Direction.South2East1;
-                }
-                // ReSharper restore ConvertIfStatementToSwitchStatement
-            }
-            return Direction.Unknown;
-        }
 
 
         private static int GetShortestDistance(int Square, int[] OtherSquares)
@@ -1014,6 +934,9 @@ namespace ErikTheCoder.MadChess.Engine
 
         public bool ValidateMove(ref ulong Move)
         {
+            // Don't trust move that wasn't generated by engine (from cache, game notation, input by user, etc).
+            // Validate main aspects of the move.  Don't test for every impossibility.
+            // Goal is to avoid engine crashes, not ensure a perfectly legal search tree.
             int fromSquare = Engine.Move.From(Move);
             int toSquare = Engine.Move.To(Move);
             int attacker = CurrentPosition.GetPiece(fromSquare);
@@ -1022,6 +945,7 @@ namespace ErikTheCoder.MadChess.Engine
             if (CurrentPosition.WhiteMove != attackerWhite) return false; // Piece is wrong color.
             int victim = CurrentPosition.GetPiece(toSquare);
             if ((victim != Piece.None) && (attackerWhite == Piece.IsWhite(victim))) return false; // Piece cannot attack its own color.
+            if ((victim == Piece.WhiteKing) || (victim == Piece.BlackKing)) return false;  // Piece cannot attack king.
             int promotedPiece = Engine.Move.PromotedPiece(Move);
             if ((promotedPiece != Piece.None) && (CurrentPosition.WhiteMove != Piece.IsWhite(promotedPiece))) return false; // Promoted piece is wrong color.
             int pawn;
@@ -1041,9 +965,51 @@ namespace ErikTheCoder.MadChess.Engine
                 king = Piece.BlackKing;
                 enPassantVictim = Piece.WhitePawn;
             }
+            if ((promotedPiece != Piece.None) && (attacker != pawn)) return false; // Only pawns can promote.
+            if ((promotedPiece == pawn) || (promotedPiece == king)) return false; // Cannot promote pawn to pawn or king.
+            bool castling = (attacker == king) && (SquareDistances[fromSquare][toSquare] == 2);
+            if (castling)
+            {
+                // ReSharper disable ConvertIfStatementToSwitchStatement
+                if (CurrentPosition.WhiteMove)
+                {
+                    // White Castling
+                    if ((toSquare != Square.c1) && (toSquare != Square.g1)) return false; // Castle destination square invalid.
+                    if (toSquare == Square.c1)
+                    {
+                        // Castle Queenside
+                        if (!Castling.WhiteQueenside(CurrentPosition.Castling)) return false; // Castle not possible.
+                        if ((CurrentPosition.Occupancy & WhiteCastleQEmptySquaresMask) > 0) return false; // Castle squares occupied.
+                    }
+                    else
+                    {
+                        // Castle Kingside
+                        if (!Castling.WhiteKingside(CurrentPosition.Castling)) return false; // Castle not possible.
+                        if ((CurrentPosition.Occupancy & WhiteCastleKEmptySquaresMask) > 0) return false; // Castle squares occupied.
+                    }
+                }
+                else
+                {
+                    // Black Castling
+                    if ((toSquare != Square.c8) && (toSquare != Square.g8)) return false; // Castle destination square invalid.
+                    if (toSquare == Square.c8)
+                    {
+                        // Castle Queenside
+                        if (!Castling.BlackQueenside(CurrentPosition.Castling)) return false; // Castle not possible.
+                        if ((CurrentPosition.Occupancy & BlackCastleQEmptySquaresMask) > 0) return false; // Castle squares occupied.
+                    }
+                    else
+                    {
+                        // Castle Kingside
+                        if (!Castling.BlackKingside(CurrentPosition.Castling)) return false; // Castle not possible.
+                        if ((CurrentPosition.Occupancy & BlackCastleKEmptySquaresMask) > 0) return false; // Castle squares occupied.
+                    }
+                }
+                // ReSharper restore ConvertIfStatementToSwitchStatement
+            }
+            // Set move properties.
             bool capture = victim != Piece.None;
             if (capture) Engine.Move.SetCaptureAttacker(ref Move, attacker);
-            bool castling = (attacker == king) && (SquareDistances[fromSquare][toSquare] == 2);
             Engine.Move.SetIsCastling(ref Move, castling);
             Engine.Move.SetIsKingMove(ref Move, attacker == king);
             bool enPassantCapture = (attacker == pawn) && (toSquare == CurrentPosition.EnPassantSquare);
@@ -1080,6 +1046,15 @@ namespace ErikTheCoder.MadChess.Engine
             int kingSquare = CurrentPosition.WhiteMove
                 ? Bitwise.FindFirstSetBit(CurrentPosition.BlackKing)
                 : Bitwise.FindFirstSetBit(CurrentPosition.WhiteKing);
+
+
+            //if (SafeRandom.NextInt(0, 100) == 0) kingSquare = Square.Illegal;
+            if (kingSquare == Square.Illegal)
+            {
+                throw new Exception($"Determine if moving piece exposes king to check.  King square is illegal.{Environment.NewLine}{ToString()}{Environment.NewLine}Move = {Engine.Move.ToString(Move)}.");
+            }
+
+
             if (IsSquareAttacked(kingSquare))
             {
                 UndoMove();
@@ -1097,6 +1072,14 @@ namespace ErikTheCoder.MadChess.Engine
             kingSquare = CurrentPosition.WhiteMove
                 ? Bitwise.FindFirstSetBit(CurrentPosition.BlackKing)
                 : Bitwise.FindFirstSetBit(CurrentPosition.WhiteKing);
+
+
+            if (kingSquare == Square.Illegal)
+            {
+                throw new Exception($"Determine if move checks enemy king.  King square is illegal.{Environment.NewLine}{ToString()}{Environment.NewLine}Move = {Engine.Move.ToString(Move)}.");
+            }
+
+
             bool check = IsSquareAttacked(kingSquare);
             UndoMove();
             Engine.Move.SetIsCheck(ref Move, check);
@@ -1186,6 +1169,7 @@ namespace ErikTheCoder.MadChess.Engine
 
         public void PlayMove(ulong Move)
         {
+            Debug.Assert(Engine.Move.IsValid(Move));
             Debug.Assert(AssertMoveIntegrity(Move));
             CurrentPosition.PlayedMove = Move;
             // Advance position index.
@@ -1209,13 +1193,12 @@ namespace ErikTheCoder.MadChess.Engine
             }
             else
             {
-                // Move piece and remove capture victim (none if destination square is unoccupied).
+                // Remove capture victim (none if destination square is unoccupied) and move piece.
                 captureVictim = RemovePiece(toSquare);
                 Debug.Assert(AssertKingIsNotCaptured(captureVictim, Move));
                 RemovePiece(fromSquare);
                 int promotedPiece = Engine.Move.PromotedPiece(Move);
                 AddPiece(promotedPiece == Piece.None ? piece : promotedPiece, toSquare);
-                if (Engine.Move.IsDoublePawnMove(Move)) CurrentPosition.EnPassantSquare = _enPassantTargetSquares[toSquare];
             }
             if (Castling.IsPossible(CurrentPosition.Castling))
             {
@@ -1261,7 +1244,7 @@ namespace ErikTheCoder.MadChess.Engine
             }
             // Update en passant capture square, move counts, side to move, position key, and nodes.
             CurrentPosition.EnPassantSquare = Engine.Move.IsDoublePawnMove(Move) ? _enPassantTargetSquares[toSquare] : Square.Illegal;
-            if (captureVictim != Piece.None || Engine.Move.IsPawnMove(Move)) CurrentPosition.HalfMoveNumber = 0;
+            if ((captureVictim != Piece.None) || Engine.Move.IsPawnMove(Move)) CurrentPosition.HalfMoveNumber = 0;
             else CurrentPosition.HalfMoveNumber++;
             if (!CurrentPosition.WhiteMove) CurrentPosition.FullMoveNumber++;
             CurrentPosition.WhiteMove = !CurrentPosition.WhiteMove;
@@ -1343,14 +1326,14 @@ namespace ErikTheCoder.MadChess.Engine
                 switch (ToSquare)
                 {
                     case Square.c1:
-                        // White castle queenside
+                        // White Castle Queenside
                         RemovePiece(Square.e1);
                         AddPiece(Engine.Piece.WhiteKing, Square.c1);
                         RemovePiece(Square.a1);
                         AddPiece(Engine.Piece.WhiteRook, Square.d1);
                         break;
                     case Square.g1:
-                        // White castle kingside
+                        // White Castle Kingside
                         RemovePiece(Square.e1);
                         AddPiece(Engine.Piece.WhiteKing, Square.g1);
                         RemovePiece(Square.h1);
@@ -1363,14 +1346,14 @@ namespace ErikTheCoder.MadChess.Engine
                 switch (ToSquare)
                 {
                     case Square.c8:
-                        // Black castle queenside
+                        // Black Castle Queenside
                         RemovePiece(Square.e8);
                         AddPiece(Engine.Piece.BlackKing, Square.c8);
                         RemovePiece(Square.a8);
                         AddPiece(Engine.Piece.BlackRook, Square.d8);
                         break;
                     case Square.g8:
-                        // Black castle kingside
+                        // Black Castle Kingside
                         RemovePiece(Square.e8);
                         AddPiece(Engine.Piece.BlackKing, Square.g8);
                         RemovePiece(Square.h8);
@@ -1611,6 +1594,16 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
-        public override string ToString() => CurrentPosition.ToString();
+        public override string ToString()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int index = 0; index <= _positionIndex; index++)
+            {
+                stringBuilder.AppendLine($"Position index = {index}.");
+                stringBuilder.AppendLine(_positions[index].ToString());
+                stringBuilder.AppendLine();
+            }
+            return stringBuilder.ToString();
+        }
     }
 }

--- a/Engine/Board.cs
+++ b/Engine/Board.cs
@@ -1046,15 +1046,6 @@ namespace ErikTheCoder.MadChess.Engine
             int kingSquare = CurrentPosition.WhiteMove
                 ? Bitwise.FindFirstSetBit(CurrentPosition.BlackKing)
                 : Bitwise.FindFirstSetBit(CurrentPosition.WhiteKing);
-
-
-            //if (SafeRandom.NextInt(0, 100) == 0) kingSquare = Square.Illegal;
-            if (kingSquare == Square.Illegal)
-            {
-                throw new Exception($"Determine if moving piece exposes king to check.  King square is illegal.{Environment.NewLine}{ToString()}{Environment.NewLine}Move = {Engine.Move.ToString(Move)}.");
-            }
-
-
             if (IsSquareAttacked(kingSquare))
             {
                 UndoMove();
@@ -1072,14 +1063,6 @@ namespace ErikTheCoder.MadChess.Engine
             kingSquare = CurrentPosition.WhiteMove
                 ? Bitwise.FindFirstSetBit(CurrentPosition.BlackKing)
                 : Bitwise.FindFirstSetBit(CurrentPosition.WhiteKing);
-
-
-            if (kingSquare == Square.Illegal)
-            {
-                throw new Exception($"Determine if move checks enemy king.  King square is illegal.{Environment.NewLine}{ToString()}{Environment.NewLine}Move = {Engine.Move.ToString(Move)}.");
-            }
-
-
             bool check = IsSquareAttacked(kingSquare);
             UndoMove();
             Engine.Move.SetIsCheck(ref Move, check);

--- a/Engine/Cache.cs
+++ b/Engine/Cache.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -48,6 +48,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public CachedPosition GetPosition(ulong Key)
         {
             int index = GetIndex(Key);
@@ -67,6 +68,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public void SetPosition(CachedPosition CachedPosition)
         {
             CachedPositionData.SetLastAccessed(ref CachedPosition.Data, Searches);
@@ -96,6 +98,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public ulong GetBestMove(CachedPosition Position)
         {
             if (Position.Key == 0) return Move.Null;

--- a/Engine/CachedPosition.cs
+++ b/Engine/CachedPosition.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/CachedPositionData.cs
+++ b/Engine/CachedPositionData.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -87,10 +87,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Data &= _toHorizonUnmask;
             // Set.
-            Data |= (ulong)ToHorizon << _toHorizonShift;
+            Data |= ((ulong)ToHorizon << _toHorizonShift) & _toHorizonMask;
             // Validate cached position.
-            Debug.Assert(Engine.CachedPositionData.ToHorizon(Data) == ToHorizon);
-            Debug.Assert(IsValid(Data));
+            Debug.Assert(CachedPositionData.ToHorizon(Data) == ToHorizon);
         }
 
 
@@ -104,10 +103,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Data &= _bestMoveFromUnmask;
             // Set.
-            Data |= (ulong)BestMoveFrom << _bestMoveFromShift;
+            Data |= ((ulong)BestMoveFrom << _bestMoveFromShift) & _bestMoveFromMask;
             // Validate cached position.
-            Debug.Assert(Engine.CachedPositionData.BestMoveFrom(Data) == BestMoveFrom);
-            Debug.Assert(IsValid(Data));
+            Debug.Assert(CachedPositionData.BestMoveFrom(Data) == BestMoveFrom);
         }
 
 
@@ -121,10 +119,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Data &= _bestMoveToUnmask;
             // Set.
-            Data |= (ulong)BestMoveTo << _bestMoveToShift;
+            Data |= ((ulong)BestMoveTo << _bestMoveToShift) & _bestMoveToMask;
             // Validate cached position.
-            Debug.Assert(Engine.CachedPositionData.BestMoveTo(Data) == BestMoveTo);
-            Debug.Assert(IsValid(Data));
+            Debug.Assert(CachedPositionData.BestMoveTo(Data) == BestMoveTo);
         }
 
 
@@ -138,10 +135,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Data &= _bestMovePromotedPieceUnmask;
             // Set.
-            Data |= (ulong)BestMovePromotedPiece << _bestMovePromotedPieceShift;
+            Data |= ((ulong)BestMovePromotedPiece << _bestMovePromotedPieceShift) & _bestMovePromotedPieceMask;
             // Validate cached position.
-            Debug.Assert(Engine.CachedPositionData.BestMovePromotedPiece(Data) == BestMovePromotedPiece);
-            Debug.Assert(IsValid(Data));
+            Debug.Assert(CachedPositionData.BestMovePromotedPiece(Data) == BestMovePromotedPiece);
         }
 
 
@@ -157,10 +153,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Data &= _scoreUnmask;
             // Set.
-            Data |= (ulong)score << _scoreShift;
+            Data |= ((ulong)score << _scoreShift) & _scoreMask;
             // Validate cached position.
-            Debug.Assert(Engine.CachedPositionData.Score(Data) == Score);
-            Debug.Assert(IsValid(Data));
+            Debug.Assert(CachedPositionData.Score(Data) == Score);
         }
 
 
@@ -175,10 +170,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Data &= _scorePrecisionUnmask;
             // Set.
-            Data |= scorePrecision << _scorePrecisionShift;
+            Data |= (scorePrecision << _scorePrecisionShift) & _scorePrecisionMask;
             // Validate cached position.
-            Debug.Assert(Engine.CachedPositionData.ScorePrecision(Data) == ScorePrecision);
-            Debug.Assert(IsValid(Data));
+            Debug.Assert(CachedPositionData.ScorePrecision(Data) == ScorePrecision);
         }
 
 
@@ -192,27 +186,25 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Data &= _lastAccessedUnmask;
             // Set.
-            Data |= LastAccessed;
+            Data |= LastAccessed & _lastAccessedMask;
             // Validate cached position.
-            Debug.Assert(Engine.CachedPositionData.LastAccessed(Data) == LastAccessed);
-            Debug.Assert(IsValid(Data));
+            Debug.Assert(CachedPositionData.LastAccessed(Data) == LastAccessed);
         }
 
 
         public static void Clear(ref ulong Data)
         {
-            // Set score first so padding is applied, ensuring a positive number is stored. 
-            SetScore(ref Data, StaticScore.NotCached);
             SetToHorizon(ref Data, 0);
             SetBestMoveFrom(ref Data, Square.Illegal); // An illegal square indicates no best move stored in cached position.
             SetBestMoveTo(ref Data, Square.Illegal);
             SetBestMovePromotedPiece(ref Data, Piece.None);
+            SetScore(ref Data, StaticScore.NotCached);
             SetScorePrecision(ref Data, Engine.ScorePrecision.Unknown);
             SetLastAccessed(ref Data, 0);
         }
 
 
-        private static bool IsValid(ulong Data)
+        public static bool IsValid(ulong Data)
         {
             Debug.Assert(ToHorizon(Data) <= Search.MaxHorizon);
             Debug.Assert(BestMoveFrom(Data) <= Square.Illegal);

--- a/Engine/Castling.cs
+++ b/Engine/Castling.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -36,10 +36,10 @@ namespace ErikTheCoder.MadChess.Engine
         // 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
         //                                                         K|Q|k|q
 
-        // K = White castle kingside
-        // Q = White castle queenside
-        // k = Black castle kingside
-        // q = Black castle queenside
+        // K = White Castle Kingside
+        // Q = White Castle Queenside
+        // k = Black Castle Kingside
+        // q = Black Castle Queenside
 
 
         static Castling()
@@ -74,7 +74,7 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear.
             Castling &= _whiteKingsideUnmask;
             // Set.
-            Castling |= whiteKingSide << _whiteKingsideShift;
+            Castling |= (whiteKingSide << _whiteKingsideShift) & _whiteKingsideMask;
             // Validate move.
             Debug.Assert(Engine.Castling.WhiteKingside(Castling) == WhiteKingside);
         }
@@ -91,7 +91,7 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear.
             Castling &= _whiteQueensideUnmask;
             // Set.
-            Castling |= whiteQueenside << _whiteQueensideShift;
+            Castling |= (whiteQueenside << _whiteQueensideShift) & _whiteQueensideMask;
             // Validate move.
             Debug.Assert(Engine.Castling.WhiteQueenside(Castling) == WhiteQueenside);
         }
@@ -108,7 +108,7 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear.
             Castling &= _blackKingsideUnmask;
             // Set.
-            Castling |= blackKingSide << _blackKingsideShift;
+            Castling |= (blackKingSide << _blackKingsideShift) & _blackKingsideMask;
             // Validate move.
             Debug.Assert(Engine.Castling.BlackKingside(Castling) == BlackKingside);
         }
@@ -125,7 +125,7 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear.
             Castling &= _blackQueensideUnmask;
             // Set.
-            Castling |= blackQueenside;
+            Castling |= blackQueenside & _blackQueensideMask;
             // Validate move.
             Debug.Assert(Engine.Castling.BlackQueenside(Castling) == BlackQueenside);
         }

--- a/Engine/CommandDirection.cs
+++ b/Engine/CommandDirection.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Delegates.cs
+++ b/Engine/Delegates.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Direction.cs
+++ b/Engine/Direction.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Evaluation.cs
+++ b/Engine/Evaluation.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -278,6 +278,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsDrawnEndgame(Position Position)
         {
             if (Bitwise.CountSetBits(Position.WhitePawns | Position.BlackPawns) > 0) return false; // At least one pawn on board.
@@ -758,6 +759,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsFreePawn(Position Position, int Square, bool White)
         {
             Debug.Assert(Position.GetPiece(Square) == (White ? Piece.WhitePawn : Piece.BlackPawn));

--- a/Engine/EvaluationConfig.cs
+++ b/Engine/EvaluationConfig.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/EvaluationStats.cs
+++ b/Engine/EvaluationStats.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/GameResult.cs
+++ b/Engine/GameResult.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/KillerMove.cs
+++ b/Engine/KillerMove.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/KillerMoves.cs
+++ b/Engine/KillerMoves.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Move.cs
+++ b/Engine/Move.cs
@@ -1,6 +1,6 @@
 // +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -143,12 +143,12 @@ namespace ErikTheCoder.MadChess.Engine
             _toUnmask = Bitwise.CreateULongUnmask(0, 6);
             // Set null move.
             Null = 0;
-            SetHistory(ref Null, 0); // Set history first to avoid debug assertion failing.
             SetIsBest(ref Null, false);
             SetCaptureVictim(ref Null, Piece.None);
             SetCaptureAttacker(ref Null, Piece.None);
             SetPromotedPiece(ref Null, Piece.None);
             SetKiller(ref Null, 0);
+            SetHistory(ref Null, 0);
             SetPlayed(ref Null, false);
             SetIsCastling(ref Null, false);
             SetIsKingMove(ref Null, false);
@@ -173,10 +173,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _bestUnmask;
             // Set
-            Move |= isBest << _bestShift;
+            Move |= (isBest << _bestShift) & _bestMask;
             // Validate move.
             Debug.Assert(Engine.Move.IsBest(Move) == IsBest);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -190,10 +189,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _captureVictimUnmask;
             // Set
-            Move |= (ulong)CaptureVictim << _captureVictimShift;
+            Move |= ((ulong)CaptureVictim << _captureVictimShift) & _captureVictimMask;
             // Validate move.
             Debug.Assert(Engine.Move.CaptureVictim(Move) == CaptureVictim);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -214,10 +212,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _captureAttackerUnmask;
             // Set
-            Move |= storedPiece << _captureAttackerShift;
+            Move |= (storedPiece << _captureAttackerShift) & _captureAttackerMask;
             // Validate move.
             Debug.Assert(Engine.Move.CaptureAttacker(Move) == CaptureAttacker);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -231,10 +228,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _promotedPieceUnmask;
             // Set.
-            Move |= (ulong)PromotedPiece << _promotedPieceShift;
+            Move |= ((ulong)PromotedPiece << _promotedPieceShift) & _promotedPieceMask;
             // Validate move.
             Debug.Assert(Engine.Move.PromotedPiece(Move) == PromotedPiece);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -248,10 +244,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _killerUnmask;
             // Set
-            Move |= (ulong)Killer << _killerShift;
+            Move |= ((ulong)Killer << _killerShift) & _killerMask;
             // Validate move.
             Debug.Assert(Engine.Move.Killer(Move) == Killer);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -267,10 +262,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _historyUnmask;
             // Set
-            Move |= (ulong)history << _historyShift;
+            Move |= ((ulong)history << _historyShift) & _historyMask;
             // Validate move.
             Debug.Assert(Engine.Move.History(Move) == History);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -285,10 +279,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _playedUnmask;
             // Set
-            Move |= played << _playedShift;
+            Move |= (played << _playedShift) & _playedMask;
             // Validate move.
             Debug.Assert(Engine.Move.Played(Move) == Played);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -303,10 +296,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _castlingUnmask;
             // Set
-            Move |= isCastling << _castlingShift;
+            Move |= (isCastling << _castlingShift) & _castlingMask;
             // Validate move.
             Debug.Assert(Engine.Move.IsCastling(Move) == IsCastling);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -321,10 +313,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _kingMoveUnmask;
             // Set
-            Move |= isKingMove << _kingMoveShift;
+            Move |= (isKingMove << _kingMoveShift) & _kingMoveMask;
             // Validate move.
             Debug.Assert(Engine.Move.IsKingMove(Move) == IsKingMove);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -339,10 +330,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _enPassantUnmask;
             // Set
-            Move |= isEnPassantCapture << _enPassantShift;
+            Move |= (isEnPassantCapture << _enPassantShift) & _enPassantMask;
             // Validate move.
             Debug.Assert(Engine.Move.IsEnPassantCapture(Move) == IsEnPassantCapture);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -357,10 +347,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _pawnMoveUnmask;
             // Set
-            Move |= isPawnMove << _pawnMoveShift;
+            Move |= (isPawnMove << _pawnMoveShift) & _pawnMoveMask;
             // Validate move.
             Debug.Assert(Engine.Move.IsPawnMove(Move) == IsPawnMove);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -375,10 +364,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _checkUnmask;
             // Set
-            Move |= isCheck << _checkShift;
+            Move |= (isCheck << _checkShift) & _checkMask;
             // Validate move.
             Debug.Assert(Engine.Move.IsCheck(Move) == IsCheck);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -393,10 +381,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _doublePawnMoveUnmask;
             // Set
-            Move |= isDoublePawnMove << _doublePawnMoveShift;
+            Move |= (isDoublePawnMove << _doublePawnMoveShift) & _doublePawnMoveMask;
             // Validate move.
             Debug.Assert(Engine.Move.IsDoublePawnMove(Move) == IsDoublePawnMove);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -411,10 +398,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _quietUnmask;
             // Set
-            Move |= isQuiet << _quietShift;
+            Move |= (isQuiet << _quietShift) & _quietMask;
             // Validate move.
             Debug.Assert(Engine.Move.IsQuiet(Move) == IsQuiet);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -428,10 +414,9 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _fromUnmask;
             // Set
-            Move |= (ulong)From << _fromShift;
+            Move |= ((ulong)From << _fromShift) & _fromMask;
             // Validate move.
             Debug.Assert(Engine.Move.From(Move) == From);
-            Debug.Assert(IsValid(Move));
         }
 
 
@@ -445,13 +430,13 @@ namespace ErikTheCoder.MadChess.Engine
             // Clear
             Move &= _toUnmask;
             // Set
-            Move |= (uint)To;
+            Move |= (ulong)To & _toMask;
             // Validate move.
             Debug.Assert(Engine.Move.To(Move) == To);
-            Debug.Assert(IsValid(Move));
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Equals(ulong Move1, ulong Move2)
         {
             if (From(Move1) == From(Move2))
@@ -628,7 +613,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
-        private static bool IsValid(ulong Move)
+        public static bool IsValid(ulong Move)
         {
             Debug.Assert(CaptureVictim(Move) >= Piece.None);
             Debug.Assert(CaptureVictim(Move) < Piece.BlackKing);
@@ -664,8 +649,9 @@ namespace ErikTheCoder.MadChess.Engine
 
         public static string ToString(ulong Move)
         {
-            return $"{ToLongAlgebraic(Move)} (B = {IsBest(Move)}, CapV = {Piece.GetChar(CaptureVictim(Move))}, CapA = {Piece.GetChar(CaptureAttacker(Move))}, Promo = {Piece.GetChar(PromotedPiece(Move))}, O = {IsCastling(Move)}, " +
-                   $"K = {IsKingMove(Move)}, E = {IsEnPassantCapture(Move)}, D = {IsDoublePawnMove(Move)}, P = {IsPawnMove(Move)}, C = {IsCheck(Move)}, Q = {IsQuiet(Move)}";
+            return $"{ToLongAlgebraic(Move)} (B = {IsBest(Move)}, CapV = {Piece.GetChar(CaptureVictim(Move))}, CapA = {Piece.GetChar(CaptureAttacker(Move))}, Promo = {Piece.GetChar(PromotedPiece(Move))}, Kil = {Killer(Move)}, " +
+                   $"! = {Played(Move)},  O = {IsCastling(Move)}, K = {IsKingMove(Move)}, E = {IsEnPassantCapture(Move)}, 2 = {IsDoublePawnMove(Move)}, P = {IsPawnMove(Move)}, C = {IsCheck(Move)}, Q = {IsQuiet(Move)} " +
+                $"From = {From(Move)}, To = {To(Move)}";
         }
     }
 }

--- a/Engine/MoveGeneration.cs
+++ b/Engine/MoveGeneration.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/MoveGenerationStage.cs
+++ b/Engine/MoveGenerationStage.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/MoveHistory.cs
+++ b/Engine/MoveHistory.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/MovePriorityComparer.cs
+++ b/Engine/MovePriorityComparer.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -9,12 +9,14 @@
 
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 
 namespace ErikTheCoder.MadChess.Engine
 {
     public sealed class MovePriorityComparer : IComparer<ulong>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(ulong Move1, ulong Move2)
         {
             // Sort moves by priority descending.

--- a/Engine/MoveScoreComparer.cs
+++ b/Engine/MoveScoreComparer.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -9,12 +9,14 @@
 
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 
 namespace ErikTheCoder.MadChess.Engine
 {
     public sealed class MoveScoreComparer : IComparer<int>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(int Score1, int Score2)
         {
             // Sort moves by score descending.

--- a/Engine/PgnGame.cs
+++ b/Engine/PgnGame.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/PgnGames.cs
+++ b/Engine/PgnGames.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Piece.cs
+++ b/Engine/Piece.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Position.cs
+++ b/Engine/Position.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -9,6 +9,7 @@
 
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 
@@ -60,27 +61,26 @@ namespace ErikTheCoder.MadChess.Engine
 
         public int GetPiece(int Square)
         {
-            // Testing redundant piece array (in feature/redundant-piece-array branch) revealed zero strength improvement compared to this bitboard code.
             ulong squareMask = Board.SquareMasks[Square];
             if ((Occupancy & squareMask) == 0) return Piece.None;
             if ((OccupancyWhite & squareMask) > 0)
             {
                 // Locate white piece.
-                if (Bitwise.FindFirstSetBit(WhitePawns & squareMask) != Engine.Square.Illegal) return Piece.WhitePawn;
-                if (Bitwise.FindFirstSetBit(WhiteKnights & squareMask) != Engine.Square.Illegal) return Piece.WhiteKnight;
-                if (Bitwise.FindFirstSetBit(WhiteBishops & squareMask) != Engine.Square.Illegal) return Piece.WhiteBishop;
-                if (Bitwise.FindFirstSetBit(WhiteRooks & squareMask) != Engine.Square.Illegal) return Piece.WhiteRook;
-                if (Bitwise.FindFirstSetBit(WhiteQueens & squareMask) != Engine.Square.Illegal) return Piece.WhiteQueen;
-                if (Bitwise.FindFirstSetBit(WhiteKing & squareMask) != Engine.Square.Illegal) return Piece.WhiteKing;
+                if ((WhitePawns & squareMask) > 0) return Piece.WhitePawn;
+                if ((WhiteKnights & squareMask) > 0) return Piece.WhiteKnight;
+                if ((WhiteBishops & squareMask) > 0) return Piece.WhiteBishop;
+                if ((WhiteRooks & squareMask) > 0) return Piece.WhiteRook;
+                if ((WhiteQueens & squareMask) > 0) return Piece.WhiteQueen;
+                if ((WhiteKing & squareMask) > 0) return Piece.WhiteKing;
                 throw new Exception($"White piece not found at {Board.SquareLocations[Square]}.");
             }
             // Locate black piece.
-            if (Bitwise.FindFirstSetBit(BlackPawns & squareMask) != Engine.Square.Illegal) return Piece.BlackPawn;
-            if (Bitwise.FindFirstSetBit(BlackKnights & squareMask) != Engine.Square.Illegal) return Piece.BlackKnight;
-            if (Bitwise.FindFirstSetBit(BlackBishops & squareMask) != Engine.Square.Illegal) return Piece.BlackBishop;
-            if (Bitwise.FindFirstSetBit(BlackRooks & squareMask) != Engine.Square.Illegal) return Piece.BlackRook;
-            if (Bitwise.FindFirstSetBit(BlackQueens & squareMask) != Engine.Square.Illegal) return Piece.BlackQueen;
-            if (Bitwise.FindFirstSetBit(BlackKing & squareMask) != Engine.Square.Illegal) return Piece.BlackKing;
+            if ((BlackPawns & squareMask) > 0) return Piece.BlackPawn;
+            if ((BlackKnights & squareMask) > 0) return Piece.BlackKnight;
+            if ((BlackBishops & squareMask) > 0) return Piece.BlackBishop;
+            if ((BlackRooks & squareMask) > 0) return Piece.BlackRook;
+            if ((BlackQueens & squareMask) > 0) return Piece.BlackQueen;
+            if ((BlackKing & squareMask) > 0) return Piece.BlackKing;
             throw new Exception($"Black piece not found at {Square}.");
         }
 
@@ -140,6 +140,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private void GeneratePawnMoves(MoveGeneration MoveGeneration, ulong FromSquareMask, ulong ToSquareMask)
         {
             ulong pawns;
@@ -356,6 +357,7 @@ namespace ErikTheCoder.MadChess.Engine
 
 
         // TODO: Refactor move generation into sliders and non-sliders using a delegate to get move masks.
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private void GenerateKnightMoves(MoveGeneration MoveGeneration, ulong FromSquareMask, ulong ToSquareMask)
         {
             ulong knights;
@@ -406,6 +408,7 @@ namespace ErikTheCoder.MadChess.Engine
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private void GenerateBishopMoves(MoveGeneration MoveGeneration, ulong FromSquareMask, ulong ToSquareMask)
         {
             ulong bishops;
@@ -458,6 +461,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private void GenerateRookMoves(MoveGeneration MoveGeneration, ulong FromSquareMask, ulong ToSquareMask)
         {
             ulong rooks;
@@ -510,6 +514,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private void GenerateQueenMoves(MoveGeneration MoveGeneration, ulong FromSquareMask, ulong ToSquareMask)
         {
             ulong queens;
@@ -563,6 +568,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private void GenerateKingMoves(MoveGeneration MoveGeneration, ulong FromSquareMask, ulong ToSquareMask)
         {
             ulong king;
@@ -626,7 +632,7 @@ namespace ErikTheCoder.MadChess.Engine
             {
                 if (castleQueenside && ((Occupancy & castleQueensideMask) == 0))
                 {
-                    // Castle queenside
+                    // Castle Queenside
                     if (WhiteMove)
                     {
                         // White Move
@@ -653,7 +659,7 @@ namespace ErikTheCoder.MadChess.Engine
                 }
                 if (castleKingside && ((Occupancy & castleKingsideMask) == 0))
                 {
-                    // Castle kingside
+                    // Castle Kingside
                     if (WhiteMove)
                     {
                         // White Move
@@ -682,6 +688,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public void FindPotentiallyPinnedPieces()
         {
             int kingSquare;
@@ -856,6 +863,7 @@ namespace ErikTheCoder.MadChess.Engine
             stringBuilder.AppendLine($"Key:             {Key:X16}");
             stringBuilder.AppendLine($"Position Count:  {_board.GetPositionCount()}");
             stringBuilder.AppendLine($"King in Check:   {(KingInCheck ? "Yes" : "No")}");
+            stringBuilder.AppendLine($"Played Move:     {Move.ToString(PlayedMove)}");
             return stringBuilder.ToString();
         }
     }

--- a/Engine/PositionSolution.cs
+++ b/Engine/PositionSolution.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/PrecalculatedMoves.cs
+++ b/Engine/PrecalculatedMoves.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -11,7 +11,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 
 namespace ErikTheCoder.MadChess.Engine
@@ -351,7 +350,6 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int GetIndex(ulong Occupancy, ulong MagicMultiplier, int Shift) => (int) ((Occupancy * MagicMultiplier) >> Shift);
 
 

--- a/Engine/Program.cs
+++ b/Engine/Program.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/SafeRandom.cs
+++ b/Engine/SafeRandom.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/ScorePrecision.cs
+++ b/Engine/ScorePrecision.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Search.cs
+++ b/Engine/Search.cs
@@ -1,6 +1,6 @@
 // +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |
@@ -11,6 +11,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 
@@ -559,6 +560,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private int GetDynamicScore(Board Board, int Depth, int Horizon, bool IsNullMoveAllowed, int Alpha, int Beta)
         {
             if ((Board.Nodes > Board.NodesExamineTime) || NodesPerSecond.HasValue)
@@ -575,6 +577,7 @@ namespace ErikTheCoder.MadChess.Engine
             int toHorizon = Horizon - Depth;
             int historyIncrement = toHorizon * toHorizon;
             CachedPosition cachedPosition = _cache.GetPosition(Board.CurrentPosition.Key);
+            Debug.Assert(CachedPositionData.IsValid(cachedPosition.Data));
             ulong bestMove;
             if ((cachedPosition.Key != 0) && (Depth > 0) && (positionCount < 2))
             {
@@ -770,11 +773,12 @@ namespace ErikTheCoder.MadChess.Engine
             Board.UndoMove();
             return scoreAfterMove - scoreBeforeMove;
         }
-
+        
 
         public int GetQuietScore(Board Board, int Depth, int Horizon, ulong ToSquareMask, int Alpha, int Beta) => GetQuietScore(Board, Depth, Horizon, ToSquareMask, Alpha, Beta, _getStaticScore, true);
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private int GetQuietScore(Board Board, int Depth, int Horizon, ulong ToSquareMask, int Alpha, int Beta, Delegates.GetStaticScore GetStaticScore, bool ConsiderFutility)
         {
             if ((Board.Nodes > Board.NodesExamineTime) || NodesPerSecond.HasValue)
@@ -867,6 +871,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsPositionFutile(Position Position, int Depth, int Horizon, int StaticScore, bool IsDrawnEndgame, int Alpha, int Beta)
         {
             int toHorizon = Horizon - Depth;
@@ -883,6 +888,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsNullMoveAllowed(Position Position, int StaticScore, int Beta)
         {
             if ((StaticScore < Beta) || Position.KingInCheck) return false;
@@ -894,6 +900,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool DoesNullMoveCauseBetaCutoff(Board Board, int Depth, int Horizon, int Beta)
         {
             // Play and search null move.
@@ -905,6 +912,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         public (ulong Move, int MoveIndex) GetNextMove(Position Position, ulong ToSquareMask, int Depth, ulong BestMove)
         {
             while (true)
@@ -966,6 +974,7 @@ namespace ErikTheCoder.MadChess.Engine
 
 
         // Pass BestMove parameter even though it isn't referenced to satisfy GetNextMove delegate signature.
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static (ulong Move, int MoveIndex) GetNextCapture(Position Position, ulong ToSquareMask, int Depth, ulong BestMove)
         {
             while (true)
@@ -999,6 +1008,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private bool IsMoveFutile(Board Board, int Depth, int Horizon, ulong Move, int LegalMoveNumber, int QuietMoveNumber, int StaticScore, bool IsDrawnEndgame, int Alpha, int Beta)
         {
             int toHorizon = Horizon - Depth;
@@ -1027,6 +1037,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private int GetSearchHorizon(Board Board, int Depth, int Horizon, ulong Move, int LegalMoveNumber, int QuietMoveNumber, bool IsDrawnEndgame)
         {
             if (Depth == 0)
@@ -1054,6 +1065,7 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private int GetCachedScore(ulong PositionData, int Depth, int Horizon, int Alpha, int Beta)
         {
             int score = CachedPositionData.Score(PositionData);
@@ -1095,6 +1107,7 @@ namespace ErikTheCoder.MadChess.Engine
         public void PrioritizeMoves(Position Position, ulong[] Moves, int LastMoveIndex, ulong BestMove, int Depth) => PrioritizeMoves(Position, Moves, 0, LastMoveIndex, BestMove, Depth);
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void PrioritizeMoves(Position Position, ulong[] Moves, int FirstMoveIndex, int LastMoveIndex, ulong BestMove, int Depth)
         {
             for (int moveIndex = FirstMoveIndex; moveIndex <= LastMoveIndex; moveIndex++)
@@ -1111,18 +1124,23 @@ namespace ErikTheCoder.MadChess.Engine
         }
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SortMovesByPriority(ulong[] Moves, int LastMoveIndex) => Array.Sort(Moves, 0, LastMoveIndex + 1, _movePriorityComparer);
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SortMovesByPriority(ulong[] Moves, int FirstMoveIndex, int LastMoveIndex) => Array.Sort(Moves, FirstMoveIndex, LastMoveIndex - FirstMoveIndex + 1, _movePriorityComparer);
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SortMovesByPriority(ulong[] Moves, int[] Scores, int LastMoveIndex) => Array.Sort(Moves, Scores, 0, LastMoveIndex + 1, _movePriorityComparer);
 
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void SortMovesByScore(ulong[] Moves, int[] Scores, int LastMoveIndex) => Array.Sort(Scores, Moves, 0, LastMoveIndex + 1, _moveScoreComparer);
 
 
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private void UpdateBestMoveCache(Position CurrentPosition, int Depth, int Horizon, ulong BestMove, int Score, int Alpha, int Beta)
         {
             if (Math.Abs(Score) == StaticScore.Interrupted) return;

--- a/Engine/SearchStats.cs
+++ b/Engine/SearchStats.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Square.cs
+++ b/Engine/Square.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/StaticScore.cs
+++ b/Engine/StaticScore.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Tokens.cs
+++ b/Engine/Tokens.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Tuning/Parameter.cs
+++ b/Engine/Tuning/Parameter.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Tuning/Parameters.cs
+++ b/Engine/Tuning/Parameters.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Tuning/Particle.cs
+++ b/Engine/Tuning/Particle.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Tuning/ParticleSwarm.cs
+++ b/Engine/Tuning/ParticleSwarm.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Tuning/ParticleSwarms.cs
+++ b/Engine/Tuning/ParticleSwarms.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/Tuning/Particles.cs
+++ b/Engine/Tuning/Particles.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Engine/UciStream.cs
+++ b/Engine/UciStream.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/MadChess.sln.DotSettings
+++ b/MadChess.sln.DotSettings
@@ -225,7 +225,7 @@
 &lt;/Patterns&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">+------------------------------------------------------------------------------+&#xD;
 |                                                                              |&#xD;
-|     MadChess is developed by Erik Madsen.  Copyright 2019.                   |&#xD;
+|     MadChess is developed by Erik Madsen.  Copyright 2020.                   |&#xD;
 |     MadChess is free software.  It is distributed under the GNU General      |&#xD;
 |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |&#xD;
 |     See https://www.madchess.net/ for user and developer guides.             |&#xD;

--- a/Tests/BitwiseTests.cs
+++ b/Tests/BitwiseTests.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Tests/PositionTests.cs
+++ b/Tests/PositionTests.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Tests/SlidingMoveTests.cs
+++ b/Tests/SlidingMoveTests.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Tests/SquareTests.cs
+++ b/Tests/SquareTests.cs
@@ -1,6 +1,6 @@
 ﻿// +------------------------------------------------------------------------------+
 // |                                                                              |
-// |     MadChess is developed by Erik Madsen.  Copyright 2019.                   |
+// |     MadChess is developed by Erik Madsen.  Copyright 2020.                   |
 // |     MadChess is free software.  It is distributed under the GNU General      |
 // |     Public License Version 3 (GPLv3).  See LICENSE file for details.         |
 // |     See https://www.madchess.net/ for user and developer guides.             |

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -14,18 +14,15 @@
 		<LangVersion>latest</LangVersion>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<TieredCompilation>true</TieredCompilation>
-		<OutputType>Exe</OutputType>
+		<OutputType>Library</OutputType>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 		<PackageId>MadChess.Tests</PackageId>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-		<PackageReference Include="NUnit" Version="3.12.0" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+	  <PackageReference Include="NUnit" Version="3.12.0" />
+	  <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Resolved bug that caused engine to crash in about one quarter of one percent of games.  Determined crash was caused by `Move.SetHistory` method whose History parameter was, amazingly, too large for the allotted 26 bits (2 Pow 26 = 67,108,864) even in games at bullet time control.  Prevented bit overun by applying mask in `Move.Set` methods.

Also applied bit mask in `Castle` and `CachePositionData` static methods.  Improved move validity testing in `Board.ValidateMove method`.  Initial hypothesis was a Zobrist hash key collision caused `Cache.GetPosition` to return an invalid position to the search, which, due to insufficient move legality testing, blindly played an illegal move and corrupted board state (removed a king from the board).  This turned out not to be the cause (the bit overrun removed a king from the board) but this PR includes the move validation improvements nonetheless.

This did not affect engine strength due to the rarity of the bug.  Engine remains 2513 +/- 17 ELO at bullet time control.