### PR TITLE
Feature/multi pv improvements

### DIFF
--- a/MadChess.sln.DotSettings
+++ b/MadChess.sln.DotSettings
@@ -332,6 +332,8 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=best_0020so_0020it_0020is/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=best_0020so_0020it_0027s/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=best_0020so_0020they_0027re/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=etc_0029/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=moves_0020so_0020they_0020are/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=moves_0020so_0020they_0027re/@EntryIndexedValue">True</s:Boolean>
 	

--- a/MadChess.sln.DotSettings
+++ b/MadChess.sln.DotSettings
@@ -330,6 +330,10 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=best_0020so_0020it_0020is/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=best_0020so_0020it_0027s/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=moves_0020so_0020they_0020are/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=moves_0020so_0020they_0027re/@EntryIndexedValue">True</s:Boolean>
 	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Analyse/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=analysemode/@EntryIndexedValue">True</s:Boolean>

--- a/src/Engine/Hashtable/Cache.cs
+++ b/src/Engine/Hashtable/Cache.cs
@@ -41,7 +41,7 @@ public sealed class Cache
             _positions = null;
             GC.Collect();
 
-            var capacity = Math.Max(value, CapacityPerMegabyte);
+            var capacity = Math.Max(value, CapacityPerMegabyte); // Ensure at least one MB of cache.
             _positions = new CachedPosition[capacity];
             _indices = capacity / _buckets;
 

--- a/src/Engine/UciStream.cs
+++ b/src/Engine/UciStream.cs
@@ -347,7 +347,7 @@ public sealed class UciStream : IDisposable
     {
         // Display engine name.
         // ReSharper disable once ConvertToConstant.Local
-        var version = "3.2.1";
+        var version = "3.2.2";
 #if CPU64
         version = $"{version} x64";
 #else


### PR DESCRIPTION
Fixed bug that caused truncated principal variations when `MultiPV > 1`.  Also improved efficiency of `MultiPV` search, so it gets deeper faster.

- If at search root position and best move from cache is null, set best move from previous iteration. Otherwise set best move from internal iterative deepening.
- Allow futile moves in dynamic and quiet searches when analyzing principal variations.
- If at search root position, do not reduce first move of principal variations (but reduce later moves).
- Ensure first move of principal variations are searched first (and sorted in correct order).